### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ Segue as opcões disponiveis:
   ![Alt text](assets/images/cards/screenshots/conf-geral.png?raw=true)
 
  2. Configuração de parcelamentos:
-    ![Alt text](assets/images/cards/screenshots/paggi_checkout.png?raw=true)
+  ![Alt text](assets/images/cards/screenshots/paggi_checkout.png?raw=true)
 
  3. Checkout Pagamento PAGGI:
-   ![Alt text](assets/images/cards/screenshots/parcelamento.png?raw=true)
+  ![Alt text](assets/images/cards/screenshots/parcelamento.png?raw=true)
 
 
 

--- a/woocommerce-paggi.php
+++ b/woocommerce-paggi.php
@@ -2,7 +2,7 @@
 
 /*
   Plugin Name: Paggi for WooCommerce
-  Plugin URI: http://www.paggi.com
+  Plugin URI: https://github.com/altec-sistemas/paggi-plugin-woocommerce-ecommerce
   Description: Includes Paggi as a payment gateway to WooCommerce
   Version: 1.0.0
   Author: Paggi


### PR DESCRIPTION
Error:

```
Your plugin and author URIs are the same. A plugin URI (Uniform Resource Identifier) is a
webpage that provides details about this specific plugin. An author URI is a webpage that
provides information about the author of the plugin. Those two URIs must be different.
You are not required to provide both, so pick the one that best applies to your situation.
```